### PR TITLE
add padding option

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -89,6 +89,10 @@ pub struct ListArgs {
     /// In the output, which name to include
     #[clap(arg_enum, long="style", default_value_t=NameStyle::ShortName)]
     name_style: NameStyle,
+
+    /// In the output, which name to include
+    #[clap(short, long="padding", default_value_t=4)]
+    padding: u8,
 }
 
 impl ListArgs {
@@ -101,8 +105,8 @@ impl ListArgs {
                 // Find the ones that matches the chord name
                 match chords::ALL_CHORDS_BY_SHORT_NAME.get(&name.to_ascii_lowercase()) {
                     Some::<&Vec<&'static Chord<'static>>>(matched_chords) => matched_chords
-                        .iter()
-                        .map(|chord: &&'static Chord<'static>| -> Chord<'static> { *chord.clone() })
+                        .into_iter()
+                        .map(|chord: &&'static Chord<'static>| -> Chord<'static> { **chord })
                         .collect(),
                     None => {
                         println!("Unknown chord '{}'", name);
@@ -112,7 +116,7 @@ impl ListArgs {
             })
             .flatten()
             .collect();
-        let row = stitcher::row(chords, self.name_style);
+        let row = stitcher::row(chords, self.name_style, self.padding);
         println!("{}", row);
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -90,7 +90,7 @@ pub struct ListArgs {
     #[clap(arg_enum, long="style", default_value_t=NameStyle::ShortName)]
     name_style: NameStyle,
 
-    /// In the output, which name to include
+    /// In the output, how many spaces for padding between chords
     #[clap(short, long="padding", default_value_t=4)]
     padding: u8,
 }

--- a/src/stitcher.rs
+++ b/src/stitcher.rs
@@ -10,7 +10,7 @@ pub enum NameStyle {
     BothNames,
 }
 
-pub fn row<'a>(chords: Vec<Chord<'a>>, name_style: NameStyle) -> String {
+pub fn row<'a>(chords: Vec<Chord<'a>>, name_style: NameStyle, padding : u8) -> String {
     let display_names: Vec<String> = chords
         .iter()
         .map(|chord| match name_style {
@@ -27,14 +27,14 @@ pub fn row<'a>(chords: Vec<Chord<'a>>, name_style: NameStyle) -> String {
     let board_width = board[0].chars().count();
 
     // The 'padding' between chords horizontally
-    // Minimum 4 spaces between chords; 
+    // Minimum `padding` spaces between chords; 
     // Minimum 2 spaces between titles;
-    let padding: usize = max(4, max_display_name_width as i32 - board_width as i32 + 2) as usize;
+    let pad: usize = max(padding as i32, max_display_name_width as i32 - board_width as i32 + 2) as usize;
 
     // We need to make sure the last one has enough additional padding for the title
     let last_padding = max(0, display_names.last().unwrap().len() as i32 - board_width as i32) as usize;
     
-    let width = (board_width + padding) * num_chords - padding + last_padding;
+    let width = (board_width + pad) * num_chords - pad + last_padding;
 
     // +1 for the label - name of chord
     let height = board.len() + 1;
@@ -44,7 +44,7 @@ pub fn row<'a>(chords: Vec<Chord<'a>>, name_style: NameStyle) -> String {
     // Print the names of the chords
     for (i, display_name) in display_names.iter().enumerate() {
         for (char_id, char) in display_name.chars().enumerate() {
-            buffer[0][char_id + i * (board_width + padding)] = char;
+            buffer[0][char_id + i * (board_width + pad)] = char;
         }
     }
 
@@ -58,7 +58,7 @@ pub fn row<'a>(chords: Vec<Chord<'a>>, name_style: NameStyle) -> String {
 
         for (line_id, line) in diagram.iter().enumerate() {
             for (char_id, char) in line.chars().enumerate() {
-                buffer[line_id + 1][char_id + i * (board_width + padding)] = char;
+                buffer[line_id + 1][char_id + i * (board_width + pad)] = char;
             }
         }
     }


### PR DESCRIPTION
This PR is adding an option to control padding between listed chords:
```
$ aschord list A D  # default to 4 spaces as before
A              D
x ◯       ◯    x x ◯
╒═╤═╤═╤═╤═╕    ╒═╤═╤═╤═╤═╕
│ │ │ │ │ │    │ │ │ │ │ │
├─┼─┼─┼─┼─┤    ├─┼─┼─┼─┼─┤
│ │ ◯ ◯ ◯ │    │ │ │ ◯ │ ◯
├─┼─┼─┼─┼─┤    ├─┼─┼─┼─┼─┤
│ │ │ │ │ │    │ │ │ │ ◯ │
├─┼─┼─┼─┼─┤    ├─┼─┼─┼─┼─┤
│ │ │ │ │ │    │ │ │ │ │ │
└─┴─┴─┴─┴─┘    └─┴─┴─┴─┴─┘
$ aschord list A D --padding 1  # use 1 space for padding to save width space (e.g. when printing a tab)
A           D
x ◯       ◯ x x ◯
╒═╤═╤═╤═╤═╕ ╒═╤═╤═╤═╤═╕
│ │ │ │ │ │ │ │ │ │ │ │
├─┼─┼─┼─┼─┤ ├─┼─┼─┼─┼─┤
│ │ ◯ ◯ ◯ │ │ │ │ ◯ │ ◯
├─┼─┼─┼─┼─┤ ├─┼─┼─┼─┼─┤
│ │ │ │ │ │ │ │ │ │ ◯ │
├─┼─┼─┼─┼─┤ ├─┼─┼─┼─┼─┤
│ │ │ │ │ │ │ │ │ │ │ │
└─┴─┴─┴─┴─┘ └─┴─┴─┴─┴─┘
```

I've also fixed (I think ? - not a rust expert here ...) this warning when using `clone`:
```
   --> src/commands.rs:109:90
    |
109 |                         .map(|chord: &&'static Chord<'static>| -> Chord<'static> { *chord.clone() })
    |                                                                                          ^^^^^^^^
    |
    = note: `#[warn(suspicious_double_ref_op)]` on by default
```