### PR TITLE
Add rustfmt config, remove unused constants, enforce warnings in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Check formatting
+      run: cargo fmt --check
+    - name: Check warnings
+      run: RUSTFLAGS="-D warnings" cargo check
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "aschord"
 version = "0.3.5"
+edition = "2015"
 authors = ["Yuchen Zhong <yuchen.post@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "A command line tool for showing how to play guitar chords"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+# Keep long Chord::new() calls on one line (default fn_call_width=60 splits them)
+fn_call_width = 100

--- a/src/chord.rs
+++ b/src/chord.rs
@@ -7,9 +7,7 @@ pub struct Capo {
 
 impl Capo {
     pub const fn new(fret: u8) -> Self {
-        Self {
-            fret: fret,
-        }
+        Self { fret: fret }
     }
 }
 
@@ -38,13 +36,10 @@ pub const BARRE_FRET1: Barre = Barre::new(1);
 pub const BARRE_FRET2: Barre = Barre::new(2);
 pub const BARRE_FRET3: Barre = Barre::new(3);
 
-pub const CAPO_FRET1: Capo = Capo::new(1);
 pub const CAPO_FRET2: Capo = Capo::new(2);
 pub const CAPO_FRET3: Capo = Capo::new(3);
 pub const CAPO_FRET4: Capo = Capo::new(4);
-pub const CAPO_FRET5: Capo = Capo::new(5);
 pub const CAPO_FRET6: Capo = Capo::new(6);
-pub const CAPO_FRET7: Capo = Capo::new(7);
 pub const CAPO_FRET8: Capo = Capo::new(8);
 // pub const CAPO_FRET9: Capo = Capo::new(9);
 
@@ -52,10 +47,7 @@ pub const CAPO_FRET8: Capo = Capo::new(8);
 pub const MONOSP_DIGITS: [char; 10] = ['𝟶', '𝟷', '𝟸', '𝟹', '𝟺', '𝟻', '𝟼', '𝟽', '𝟾', '𝟿'];
 
 pub fn make_fretboard(num_frets: usize) -> String {
-    let mut lines = vec![
-        "◯ ◯ ◯ ◯ ◯ ◯".to_string(),
-        "╒═╤═╤═╤═╤═╕".to_string(),
-    ];
+    let mut lines = vec!["◯ ◯ ◯ ◯ ◯ ◯".to_string(), "╒═╤═╤═╤═╤═╕".to_string()];
     for i in 0..num_frets {
         lines.push("│ │ │ │ │ │".to_string());
         if i < num_frets - 1 {
@@ -97,15 +89,13 @@ impl<'a> Chord<'a> {
     }
 
     pub fn both_names(&self) -> String {
-        format!(
-            "{} ({})",
-            join(self.names, " | "),
-            join(self.short_names, " | ")
-        )
+        format!("{} ({})", join(self.names, " | "), join(self.short_names, " | "))
     }
 
     pub fn max_fret(&self) -> usize {
-        let pattern_max = self.pattern.chars()
+        let pattern_max = self
+            .pattern
+            .chars()
             .filter_map(|c| c.to_digit(10))
             .max()
             .unwrap_or(0) as usize;

--- a/src/chords.rs
+++ b/src/chords.rs
@@ -1,7 +1,7 @@
 use chord::Chord;
 use chord::{BARRE_FRET1, BARRE_FRET2, BARRE_FRET3};
-use chord::{CAPO_FRET1, CAPO_FRET2, CAPO_FRET3, CAPO_FRET4, CAPO_FRET5};
-use chord::{CAPO_FRET6, CAPO_FRET7, CAPO_FRET8};
+use chord::{CAPO_FRET2, CAPO_FRET3, CAPO_FRET4};
+use chord::{CAPO_FRET6, CAPO_FRET8};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 
@@ -169,9 +169,7 @@ pub static ALL_CHORDS_BY_SHORT_NAMES: Lazy<HashMap<String, Vec<&'static Chord<'s
 
         for chord in ALL_CHORDS {
             for sn in chord.short_names {
-                map.entry(sn.to_ascii_lowercase())
-                    .or_default()
-                    .push(chord);
+                map.entry(sn.to_ascii_lowercase()).or_default().push(chord);
             }
         }
         map

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -51,11 +51,9 @@ impl GetArgs {
                 .any(|&name| name.to_ascii_uppercase() == name_uppercase)
         }) {
             None => println!("Unknown chord '{}'", self.name),
-            Some(chord) => println!(
-                "This is how you play '{}' chord: \n{}",
-                self.name,
-                chord.fretboard()
-            ),
+            Some(chord) => {
+                println!("This is how you play '{}' chord: \n{}", self.name, chord.fretboard())
+            }
         }
     }
 }
@@ -108,7 +106,9 @@ impl ListArgs {
                 match chords::ALL_CHORDS_BY_SHORT_NAMES.get(&name.to_ascii_lowercase()) {
                     Some::<&Vec<&'static Chord<'static>>>(matched_chords) => matched_chords
                         .into_iter()
-                        .map(|chord: &&'static Chord<'static>| -> Chord<'static> { (*chord).clone() })
+                        .map(|chord: &&'static Chord<'static>| -> Chord<'static> {
+                            (*chord).clone()
+                        })
                         .collect(),
                     None => {
                         println!("Unknown chord '{}'", name);

--- a/src/stitcher.rs
+++ b/src/stitcher.rs
@@ -1,4 +1,4 @@
-use chord::{Chord, make_fretboard};
+use chord::{make_fretboard, Chord};
 use clap::ValueEnum;
 use itertools::join;
 use std::cmp::max;
@@ -32,16 +32,12 @@ pub fn row<'a>(chords: Vec<Chord<'a>>, name_style: NameStyle, padding: u8) -> St
     // The 'padding' between chords horizontally
     // Minimum `padding` spaces between chords
     // Minimum 1 space between titles
-    let pad: usize = max(
-        padding as i32,
-        max_display_name_width as i32 - board_width as i32 + 1,
-    ) as usize;
+    let pad: usize =
+        max(padding as i32, max_display_name_width as i32 - board_width as i32 + 1) as usize;
 
     // We need to make sure the last one has enough additional padding for the title
-    let last_padding = max(
-        0,
-        display_names.last().unwrap().len() as i32 - board_width as i32,
-    ) as usize;
+    let last_padding =
+        max(0, display_names.last().unwrap().len() as i32 - board_width as i32) as usize;
 
     let width = (board_width + pad) * num_chords - pad + last_padding;
 


### PR DESCRIPTION
## Summary

- **rustfmt.toml**: Added with `fn_call_width = 100` to keep `Chord::new(...)` calls on one line (default of 60 was expanding them and making diffs hard to read)
- **Unused code**: Removed unused constants `CAPO_FRET1`, `CAPO_FRET5`, `CAPO_FRET7` from `chord.rs` and their corresponding imports in `chords.rs`
- **CI**: Added `cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo check` steps to the GitHub Actions workflow — PRs will now fail if they introduce unused imports/variables or unformatted code
- **Cargo.toml**: Added `edition = "2015"` explicitly to silence the "no edition set" warning

## Test plan

- [ ] CI passes on this PR
- [ ] `cargo fmt --check` exits cleanly locally
- [ ] `RUSTFLAGS="-D warnings" cargo check` exits cleanly locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)